### PR TITLE
ROCANA-2098 Fix imports and backport to 1.3.3

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,4 +7,4 @@
 #
 # See golang.org/issue/9281
 
-* -text
+* text eol=crlf

--- a/plan9/syscall.go
+++ b/plan9/syscall.go
@@ -19,7 +19,7 @@
 // These calls return err == nil to indicate success; otherwise
 // err represents an operating system error describing the failure and
 // holds a value of type syscall.ErrorString.
-package plan9 // import "golang.org/x/sys/plan9"
+package plan9 // import "github.com/scalingdata/sys/plan9"
 
 import "unsafe"
 

--- a/plan9/syscall_test.go
+++ b/plan9/syscall_test.go
@@ -9,7 +9,7 @@ package plan9_test
 import (
 	"testing"
 
-	"golang.org/x/sys/plan9"
+	"github.com/scalingdata/sys/plan9"
 )
 
 func testSetGetenv(t *testing.T, key, value string) {

--- a/unix/creds_test.go
+++ b/unix/creds_test.go
@@ -13,7 +13,7 @@ import (
 	"syscall"
 	"testing"
 
-	"golang.org/x/sys/unix"
+	"github.com/scalingdata/sys/unix"
 )
 
 // TestSCMCredentials tests the sending and receiving of credentials

--- a/unix/mmap_unix_test.go
+++ b/unix/mmap_unix_test.go
@@ -9,7 +9,7 @@ package unix_test
 import (
 	"testing"
 
-	"golang.org/x/sys/unix"
+	"github.com/scalingdata/sys/unix"
 )
 
 func TestMmap(t *testing.T) {

--- a/unix/syscall.go
+++ b/unix/syscall.go
@@ -19,7 +19,7 @@
 // These calls return err == nil to indicate success; otherwise
 // err represents an operating system error describing the failure and
 // holds a value of type syscall.Errno.
-package unix // import "golang.org/x/sys/unix"
+package unix // import "github.com/scalingdata/sys/unix"
 
 import "unsafe"
 

--- a/unix/syscall_bsd_test.go
+++ b/unix/syscall_bsd_test.go
@@ -9,7 +9,7 @@ package unix_test
 import (
 	"testing"
 
-	"golang.org/x/sys/unix"
+	"github.com/scalingdata/sys/unix"
 )
 
 const MNT_WAIT = 1

--- a/unix/syscall_test.go
+++ b/unix/syscall_test.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"testing"
 
-	"golang.org/x/sys/unix"
+	"github.com/scalingdata/sys/unix"
 )
 
 func testSetGetenv(t *testing.T, key, value string) {

--- a/unix/syscall_unix_test.go
+++ b/unix/syscall_unix_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/sys/unix"
+	"github.com/scalingdata/sys/unix"
 )
 
 // Tests that below functions, structures and constants are consistent

--- a/windows/dummy.go
+++ b/windows/dummy.go
@@ -1,0 +1,3 @@
+package windows
+
+/* Placeholder so `go get` doesn't complain about a lack of files */

--- a/windows/registry/registry_test.go
+++ b/windows/registry/registry_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/sys/windows/registry"
+	"github.com/scalingdata/sys/windows/registry"
 )
 
 func randKeyName(prefix string) string {

--- a/windows/svc/debug/service.go
+++ b/windows/svc/debug/service.go
@@ -13,7 +13,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	"golang.org/x/sys/windows/svc"
+	"github.com/scalingdata/sys/windows/svc"
 )
 
 // Run executes service name by calling appropriate handler function.

--- a/windows/svc/event.go
+++ b/windows/svc/event.go
@@ -9,7 +9,7 @@ package svc
 import (
 	"errors"
 
-	"golang.org/x/sys/windows"
+	"github.com/scalingdata/sys/windows"
 )
 
 // event represents auto-reset, initially non-signaled Windows event.

--- a/windows/svc/eventlog/install.go
+++ b/windows/svc/eventlog/install.go
@@ -9,8 +9,8 @@ package eventlog
 import (
 	"errors"
 
-	"golang.org/x/sys/windows"
-	"golang.org/x/sys/windows/registry"
+	"github.com/scalingdata/sys/windows"
+	"github.com/scalingdata/sys/windows/registry"
 )
 
 const (

--- a/windows/svc/eventlog/log.go
+++ b/windows/svc/eventlog/log.go
@@ -12,7 +12,7 @@ import (
 	"errors"
 	"syscall"
 
-	"golang.org/x/sys/windows"
+	"github.com/scalingdata/sys/windows"
 )
 
 // Log provides access to the system log.

--- a/windows/svc/eventlog/log_test.go
+++ b/windows/svc/eventlog/log_test.go
@@ -9,7 +9,7 @@ package eventlog_test
 import (
 	"testing"
 
-	"golang.org/x/sys/windows/svc/eventlog"
+	"github.com/scalingdata/sys/windows/svc/eventlog"
 )
 
 func TestLog(t *testing.T) {

--- a/windows/svc/example/install.go
+++ b/windows/svc/example/install.go
@@ -11,8 +11,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"golang.org/x/sys/windows/svc/eventlog"
-	"golang.org/x/sys/windows/svc/mgr"
+	"github.com/scalingdata/sys/windows/svc/eventlog"
+	"github.com/scalingdata/sys/windows/svc/mgr"
 )
 
 func exePath() (string, error) {

--- a/windows/svc/example/main.go
+++ b/windows/svc/example/main.go
@@ -20,7 +20,7 @@ import (
 	"os"
 	"strings"
 
-	"golang.org/x/sys/windows/svc"
+	"github.com/scalingdata/sys/windows/svc"
 )
 
 func usage(errmsg string) {

--- a/windows/svc/example/manage.go
+++ b/windows/svc/example/manage.go
@@ -10,8 +10,8 @@ import (
 	"fmt"
 	"time"
 
-	"golang.org/x/sys/windows/svc"
-	"golang.org/x/sys/windows/svc/mgr"
+	"github.com/scalingdata/sys/windows/svc"
+	"github.com/scalingdata/sys/windows/svc/mgr"
 )
 
 func startService(name string) error {

--- a/windows/svc/example/service.go
+++ b/windows/svc/example/service.go
@@ -10,9 +10,9 @@ import (
 	"fmt"
 	"time"
 
-	"golang.org/x/sys/windows/svc"
-	"golang.org/x/sys/windows/svc/debug"
-	"golang.org/x/sys/windows/svc/eventlog"
+	"github.com/scalingdata/sys/windows/svc"
+	"github.com/scalingdata/sys/windows/svc/debug"
+	"github.com/scalingdata/sys/windows/svc/eventlog"
 )
 
 var elog debug.Log

--- a/windows/svc/mgr/config.go
+++ b/windows/svc/mgr/config.go
@@ -11,7 +11,7 @@ import (
 	"unicode/utf16"
 	"unsafe"
 
-	"golang.org/x/sys/windows"
+	"github.com/scalingdata/sys/windows"
 )
 
 const (

--- a/windows/svc/mgr/mgr.go
+++ b/windows/svc/mgr/mgr.go
@@ -15,7 +15,7 @@ import (
 	"syscall"
 	"unicode/utf16"
 
-	"golang.org/x/sys/windows"
+	"github.com/scalingdata/sys/windows"
 )
 
 // Mgr is used to manage Windows service.

--- a/windows/svc/mgr/mgr_test.go
+++ b/windows/svc/mgr/mgr_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/sys/windows/svc/mgr"
+	"github.com/scalingdata/sys/windows/svc/mgr"
 )
 
 func TestOpenLanManServer(t *testing.T) {

--- a/windows/svc/mgr/service.go
+++ b/windows/svc/mgr/service.go
@@ -9,8 +9,8 @@ package mgr
 import (
 	"syscall"
 
-	"golang.org/x/sys/windows"
-	"golang.org/x/sys/windows/svc"
+	"github.com/scalingdata/sys/windows"
+	"github.com/scalingdata/sys/windows/svc"
 )
 
 // TODO(brainman): Use EnumDependentServices to enumerate dependent services.

--- a/windows/svc/security.go
+++ b/windows/svc/security.go
@@ -9,7 +9,7 @@ package svc
 import (
 	"unsafe"
 
-	"golang.org/x/sys/windows"
+	"github.com/scalingdata/sys/windows"
 )
 
 func allocSid(subAuth0 uint32) (*windows.SID, error) {

--- a/windows/svc/service.go
+++ b/windows/svc/service.go
@@ -14,7 +14,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"golang.org/x/sys/windows"
+	"github.com/scalingdata/sys/windows"
 )
 
 // State describes service execution state (Stopped, Running and so on).

--- a/windows/svc/svc_test.go
+++ b/windows/svc/svc_test.go
@@ -14,8 +14,8 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/sys/windows/svc"
-	"golang.org/x/sys/windows/svc/mgr"
+	"github.com/scalingdata/sys/windows/svc"
+	"github.com/scalingdata/sys/windows/svc/mgr"
 )
 
 func getState(t *testing.T, s *mgr.Service) svc.State {
@@ -66,7 +66,7 @@ func TestExample(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	exepath := filepath.Join(dir, "a.exe")
-	o, err := exec.Command("go", "build", "-o", exepath, "golang.org/x/sys/windows/svc/example").CombinedOutput()
+	o, err := exec.Command("go", "build", "-o", exepath, "github.com/scalingdata/sys/windows/svc/example").CombinedOutput()
 	if err != nil {
 		t.Fatalf("failed to build service program: %v\n%v", err, string(o))
 	}

--- a/windows/syscall.go
+++ b/windows/syscall.go
@@ -19,7 +19,7 @@
 // These calls return err == nil to indicate success; otherwise
 // err represents an operating system error describing the failure and
 // holds a value of type syscall.Errno.
-package windows // import "golang.org/x/sys/windows"
+package windows // import "github.com/scalingdata/sys/windows"
 
 import (
 	"syscall"

--- a/windows/syscall_test.go
+++ b/windows/syscall_test.go
@@ -9,7 +9,7 @@ package windows_test
 import (
 	"testing"
 
-	"golang.org/x/sys/windows"
+	"github.com/scalingdata/sys/windows"
 )
 
 func testSetGetenv(t *testing.T, key, value string) {

--- a/windows/syscall_windows_test.go
+++ b/windows/syscall_windows_test.go
@@ -11,7 +11,7 @@ import (
 	"syscall"
 	"testing"
 
-	"golang.org/x/sys/windows"
+	"github.com/scalingdata/sys/windows"
 )
 
 func TestWin32finddata(t *testing.T) {

--- a/windows/textflag.h
+++ b/windows/textflag.h
@@ -1,0 +1,36 @@
+// Copyright 2013 The Go Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// This file defines flags attached to various functions
+// and data objects.  The compilers, assemblers, and linker must
+// all agree on these values.
+
+// Don't profile the marked routine.  This flag is deprecated.
+#define NOPROF  1
+// It is ok for the linker to get multiple of these symbols.  It will
+// pick one of the duplicates to use.
+#define DUPOK 2
+// Don't insert stack check preamble.
+#define NOSPLIT 4
+// Put this data in a read-only section.
+#define RODATA  8
+// This data contains no pointers.
+#define NOPTR 16
+// This is a wrapper function and should not count as disabling 'recover'.
+#define WRAPPER 32
+// This function uses its incoming context register.
+#define NEEDCTXT 64
+
+/*c2go
+enum
+{
+  NOPROF = 1,
+  DUPOK = 2,
+  NOSPLIT = 4,
+  RODATA = 8,
+  NOPTR = 16,
+  WRAPPER = 32,
+  NEEDCTXT = 64,
+};
+*/


### PR DESCRIPTION
Fix all the imports to reference this repo, and bring in `textflag.h` which is necessary to build on 1.3.3
