### PR TITLE
ROCANA-2133 Add convenience method to convert narrow strings

### DIFF
--- a/windows/syscall.go
+++ b/windows/syscall.go
@@ -51,6 +51,19 @@ func BytePtrFromString(s string) (*byte, error) {
 	return &a[0], nil
 }
 
+// BytePtrToString converts a narrow, null-terminated array of
+// bytes to a Go string.
+func BytePtrToString(a *byte) string {
+  if a == nil {
+    return ""
+  }
+  var i uintptr
+  ptr := uintptr(unsafe.Pointer(a))
+  for i = 0; *(*byte)(unsafe.Pointer(ptr + i)) != 0; i++ {
+  }
+  return string(((*[1<<30]byte)(unsafe.Pointer(a)))[0:i])
+}
+
 // Single-word zero for use when we need a valid pointer to 0 bytes.
 // See mksyscall.pl.
 var _zero uintptr


### PR DESCRIPTION
This is just to avoid importing `unsafe` and adding gnarly pointer arithmetic in more places. `gethostbyname` is old-school and always returns a narrow string. `C.GoString` seems like it should fit the bill, but bringing in cgo for one convenience method is gross, and it still requires an unsafe cast to convert `*byte` to `*C.char`. 

tl;dr: WTH go?
