### PR TITLE
ROCANA-2133 Add convenience method to convert *uint16 to string

### DIFF
--- a/windows/syscall.go
+++ b/windows/syscall.go
@@ -51,6 +51,26 @@ func BytePtrFromString(s string) (*byte, error) {
 	return &a[0], nil
 }
 
+// UTF16PtrToString converts a *uint16 to a string
+func UTF16PtrToString(a *uint16) string {
+  if a == nil {
+    return ""
+  }
+  var i uintptr
+  ptr := uintptr(unsafe.Pointer(a))
+
+  // Iterate until we hit a null terminator
+  for i = 0; *(*uint16)(unsafe.Pointer(ptr + i)) != 0; i++ {
+  }
+
+  // Convert the *byte to a slice now that we know the length
+  // Making a slice from a pointer requires making a 2^31 length arary
+  // and then slicing it down to the known length
+  uintSlice := ((*[1<<30]uint16)(unsafe.Pointer(a)))[0:i]
+
+  return syscall.UTF16ToString(uintSlice)
+}
+
 // Single-word zero for use when we need a valid pointer to 0 bytes.
 // See mksyscall.pl.
 var _zero uintptr

--- a/windows/ztypes_windows.go
+++ b/windows/ztypes_windows.go
@@ -1002,6 +1002,8 @@ const (
 	AI_PASSIVE     = 1
 	AI_CANONNAME   = 2
 	AI_NUMERICHOST = 4
+	
+	AI_FQDN = 0x00020000
 )
 
 type GUID struct {


### PR DESCRIPTION
I couldn't find a function to do this anywhere, so I stuck it in `sys` to avoid importing unsafe and syscall any more than we already have to.
